### PR TITLE
Fixed pyyaml ver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ packaging==16.8
 pygments==2.2.0
 pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
-PyYaml==3.12
+PyYaml==3.13
 readme-renderer==17.2
 setuptools==37.0.0
 six==1.11.0


### PR DESCRIPTION
3.13 (2018-07-05)

Rebuild wheels using latest Cython for Python 3.7 support.